### PR TITLE
fix: Generate YAML safely by js-yaml

### DIFF
--- a/lib/generators/docs/index.js
+++ b/lib/generators/docs/index.js
@@ -1,4 +1,5 @@
 const BasicGenerator = require("../../BasicGenerator");
+const yaml = require("js-yaml");
 
 class Generator extends BasicGenerator {
   prompting() {
@@ -32,7 +33,10 @@ class Generator extends BasicGenerator {
 
   writing() {
     this.writeFiles({
-      context: this.prompts,
+      context: {
+        toYAML: obj => yaml.safeDump(obj),
+        ...this.prompts
+      },
       filterFiles: () => {
         return true;
       }

--- a/lib/generators/docs/templates/docs/src/index.md
+++ b/lib/generators/docs/templates/docs/src/index.md
@@ -1,15 +1,24 @@
 ---
-home: true
-heroImage: https://v1.vuepress.vuejs.org/hero.png
-tagline: <%= description %>
-actionText: Quick Start →
-actionLink: /guide/
-features:
-- title: Feature 1 Title
-  details: Feature 1 Description
-- title: Feature 2 Title
-  details: Feature 2 Description
-- title: Feature 3 Title
-  details: Feature 3 Description
-footer: Made by <%= author %> with ❤️
+<%-
+toYAML({
+  home: true,
+  heroImage: 'https://v1.vuepress.vuejs.org/hero.png',
+  tagline: description,
+  actionText: 'Quick Start →',
+  actionLink: '/guide/',
+  features: [
+    {
+      title: 'Feature 1 Title',
+      details: 'Feature 1 Description'
+    },{
+      title: 'Feature 2 Title',
+      details: 'Feature 2 Description'
+    },{
+      title: 'Feature 3 Title',
+      details: 'Feature 3 Description'
+    }
+  ],
+  footer: `Made by ${author} with ❤️`
+})
+%>
 ---

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^8.0.1",
     "glob": "^7.1.4",
     "inquirer": "^6.2.1",
+    "js-yaml": "^3.14.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1.17.0",
     "semver": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,7 +2489,7 @@ jest-validate@^23.5.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
+js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.9.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==


### PR DESCRIPTION
Fixes #5 

## Problem

* YAML syntax is broken by non-escaped template value (See #5)
* Unnecessary escape for some chars such as `"` or `'`: They are double-escaped by EJS compiler and VuePress

## Proposal

* Use `js-yaml` to generate YAML safely
  * Inject `safeDump()` as `toYAML()` into EJS and use to generate YAML